### PR TITLE
OS X fix for accessing serial ports on /dev/tty

### DIFF
--- a/System/Hardware/Serialport/Posix.hsc
+++ b/System/Hardware/Serialport/Posix.hsc
@@ -16,7 +16,7 @@ openSerial :: FilePath            -- ^ The filename of the serial port, such as 
            -> SerialPortSettings
            -> IO SerialPort
 openSerial dev settings = do
-  fd' <- openFd dev ReadWrite Nothing defaultFileFlags { noctty = True }
+  fd' <- openFd dev ReadWrite Nothing defaultFileFlags { noctty = True , nonBlock = True }
   let serial_port = (SerialPort fd' defaultSerialSettings)
   return =<< setSerialSettings serial_port settings
 


### PR DESCRIPTION
Made a small change to the way files are opened on posix systems for OS X to work properly. It should work fine on Linux and OS X. I was primarily encountering the problem on OS X. This change allowed me to properly open serial devices connected over USB. Just wanted to let you know. 
