### PR TITLE
Use bracket in withSerial

### DIFF
--- a/System/Hardware/Serialport.hs
+++ b/System/Hardware/Serialport.hs
@@ -47,11 +47,8 @@ import System.Hardware.Serialport.Posix
 #endif
 import System.Hardware.Serialport.Types
 
+import Control.Exception (bracket)
 
 -- |Safer device function, so you don't forget to close the device
 withSerial :: String -> SerialPortSettings -> ( SerialPort -> IO a ) -> IO a
-withSerial dev settings f = do
-  s <- openSerial dev settings
-  res <- f s
-  closeSerial s
-  return res
+withSerial dev settings = bracket (openSerial dev settings) closeSerial


### PR DESCRIPTION
Hi Joris,

You probably want to use [bracket](http://hackage.haskell.org/packages/archive/base/latest/doc/html/Control-Exception.html#v:bracket) in `withSerial` to ensure that `closeSerial` is called even when an exception is thrown in the continuation.
