### PR TITLE
Implement non-blocking interface

### DIFF
--- a/System/Hardware/Serialport/Types.hs
+++ b/System/Hardware/Serialport/Types.hs
@@ -29,6 +29,8 @@ data CommSpeed
 data StopBits = One | Two
 data Parity = Even | Odd | NoParity
 data FlowControl = Software | NoFlowControl
+data Blocking = Block Int     -- ^ Block and timeout after `n` tenths of a second
+              | NonBlock      -- ^ Don't block
 
 data SerialPortSettings = SerialPortSettings {
                       commSpeed    :: CommSpeed,   -- ^ baudrate
@@ -36,7 +38,7 @@ data SerialPortSettings = SerialPortSettings {
                       stopb        :: StopBits,    -- ^ Number of stop bits
                       parity       :: Parity,      -- ^ Type of parity
                       flowControl  :: FlowControl, -- ^ Type of flowcontrol
-                      timeout      :: Int          -- ^ Timeout when receiving a char in tenth of seconds
+                      block        :: Blocking     -- ^ Timeout when receiving a char in tenth of seconds
                   }
 
 
@@ -66,5 +68,5 @@ data SerialPort = SerialPort {
 --
 defaultSerialSettings :: SerialPortSettings
 defaultSerialSettings =
-  SerialPortSettings CS9600 8 One NoParity NoFlowControl 1
+  SerialPortSettings CS9600 8 One NoParity NoFlowControl (Block 1)
 

--- a/System/Hardware/Serialport/Windows.hs
+++ b/System/Hardware/Serialport/Windows.hs
@@ -85,7 +85,10 @@ setSerialSettings :: SerialPort           -- ^ The currently opened serial port
                   -> SerialPortSettings   -- ^ The new settings
                   -> IO SerialPort        -- ^ New serial port
 setSerialSettings (SerialPort h _) new_settings = do
-  let ct = Comm.COMMTIMEOUTS {
+  let timeout = case block new_settings of
+                     Block t   -> t
+                     NonBlock  -> error "System.Hardware.Serialport.Windows: Non-blocking mode unsupported on Windows"
+      ct = Comm.COMMTIMEOUTS {
                     Comm.readIntervalTimeout = maxBound :: DWORD,
                     Comm.readTotalTimeoutMultiplier = maxBound :: DWORD,
                     Comm.readTotalTimeoutConstant = fromIntegral (timeout new_settings) * 100,


### PR DESCRIPTION
Note that this breaks compatibility in `SerialPortSettings` due to
transition to `blocking` field. This warrants a large version bump.

There should also be some updating of the documentation to clarify the behavior of non-blocking reads and writes, but I'll wait until we agree this is the correct approach before doing this.
