### PR TITLE
Add support for four more baud rates

### DIFF
--- a/System/Hardware/Serialport/Posix.hsc
+++ b/System/Hardware/Serialport/Posix.hsc
@@ -233,6 +233,7 @@ commSpeedToBaudRate :: CommSpeed -> BaudRate
 commSpeedToBaudRate speed =
     case speed of
       CS110 -> B110
+      CS150 -> B150
       CS300 -> B300
       CS600 -> B600
       CS1200 -> B1200
@@ -243,5 +244,8 @@ commSpeedToBaudRate speed =
       CS38400 -> B38400
       CS57600 -> B57600
       CS115200 -> B115200
+      CS230400 -> B230400
+      CS460800 -> B460800
+      CS921600 -> B921600
 
 

--- a/System/Hardware/Serialport/Types.hs
+++ b/System/Hardware/Serialport/Types.hs
@@ -7,6 +7,7 @@ import Data.Word
 -- | Supported baudrates
 data CommSpeed
   = CS110
+  | CS150
   | CS300
   | CS600
   | CS1200
@@ -17,6 +18,9 @@ data CommSpeed
   | CS38400
   | CS57600
   | CS115200
+  | CS230400
+  | CS460800
+  | CS921600
   deriving (Show, Eq, Bounded)
 
 

--- a/System/Win32/Comm.hsc
+++ b/System/Win32/Comm.hsc
@@ -220,6 +220,7 @@ commSpeedToBaudRate :: CommSpeed -> Int
 commSpeedToBaudRate cs =
     case cs of
       CS110 -> (#const CBR_110)
+      CS150 -> 150
       CS300 -> (#const CBR_300)
       CS600 -> (#const CBR_600)
       CS1200 -> (#const CBR_1200)
@@ -230,3 +231,6 @@ commSpeedToBaudRate cs =
       CS38400 -> (#const CBR_38400)
       CS57600 -> (#const CBR_57600)
       CS115200 -> (#const CBR_115200)
+      CS230400 -> 230400
+      CS460800 -> 460800
+      CS921600 -> 921600


### PR DESCRIPTION
This commit adds support for speeds of 150, 230400, 460800, and 921600 baud. The available baud rates are now those that are available both in [Realterm](http://realterm.sourceforge.net) version 2.0.0.70 and as preprocessor macros in [`termbits.h`](https://github.com/torvalds/linux/blob/v4.0/include/uapi/asm-generic/termbits.h) in the 4.0 release of the Linux kernel.
