### PR TITLE
Support other baud rates

### DIFF
--- a/System/Hardware/Serialport/Posix.hsc
+++ b/System/Hardware/Serialport/Posix.hsc
@@ -243,5 +243,7 @@ commSpeedToBaudRate speed =
       CS38400 -> B38400
       CS57600 -> B57600
       CS115200 -> B115200
+      CSOther x -> BOther x
+
 
 

--- a/System/Hardware/Serialport/Types.hs
+++ b/System/Hardware/Serialport/Types.hs
@@ -17,7 +17,8 @@ data CommSpeed
   | CS38400
   | CS57600
   | CS115200
-  deriving (Show, Eq, Bounded)
+  | CSOther Word64
+  deriving (Show, Eq)
 
 
 data StopBits = One | Two deriving (Show, Eq, Bounded)

--- a/System/Win32/Comm.hsc
+++ b/System/Win32/Comm.hsc
@@ -230,3 +230,4 @@ commSpeedToBaudRate cs =
       CS38400 -> (#const CBR_38400)
       CS57600 -> (#const CBR_57600)
       CS115200 -> (#const CBR_115200)
+      CSOther x -> fromIntegral x


### PR DESCRIPTION
Depends on https://github.com/haskell/unix/pull/74.

We're using higher baud rates not defined - we'd like to access them if our underlying system can support them. The limited set of baud rates is currently too restrictive - this allows an escape hatch.
